### PR TITLE
fix: avoid table overflow when decoding proto contains oneof

### DIFF
--- a/pb.c
+++ b/pb.c
@@ -1170,7 +1170,7 @@ typedef enum {USE_FIELD = 1, USE_REPEAT = 2, USE_MESSAGE = 4} lpb_DefFlags;
 static void lpb_pushtypetable(lua_State *L, lpb_State *LS, const pb_Type *t);
 
 static void lpb_newmsgtable(lua_State *L, const pb_Type *t)
-{ lua_createtable(L, 0, t->field_count - t->oneof_field + t->oneof_count*2); }
+{ lua_createtable(L, 0, t->field_count + t->oneof_count); }
 
 LUALIB_API const pb_Type *lpb_type(lpb_State *LS, pb_Slice s) {
     const pb_Type *t;


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

I haven't found a way to reproduce it with a minimal test case. It seems that this bug requires complex proto definition. 
But it can be verified via APISIX's CI, like https://github.com/apache/apisix/actions/runs/3561181506/jobs/5981858792 (`{"error_msg":"failed to decode: table overflow"}`)